### PR TITLE
Change float64_t to typedef in pkmn.h

### DIFF
--- a/examples/c/Makefile
+++ b/examples/c/Makefile
@@ -28,7 +28,7 @@
 # linked. Some documentation suggests that GCC requires the static library to be
 # named libpkmn.a instead of pkmn.lib, but the latter seems to work fine.
 
-ROOT=../../build
+ROOT=../../zig-out
 CFLAGS = -Wall -Wextra -pedantic -std=c99 -I$(ROOT)/include
 
 suffix ?= $(if $(findstring showdown,$(options)),-showdown,)

--- a/src/include/pkmn.h
+++ b/src/include/pkmn.h
@@ -33,14 +33,12 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 
-#ifndef float64_t
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 #include <assert.h>
 #include <limits.h>
 static_assert(sizeof(double) * CHAR_BIT == 64, "libpkmn requires IEEE 754 64-bit doubles");
 #endif
-#define float64_t double
-#endif
+typedef double float64_t;
 
 /**
  * Defines an opaque pkmn type. These are given a size so that they may be


### PR DESCRIPTION
Change float64_t to be a typedef instead of a #define similar to how uint64_t and other types are defined in stdint.h. This helps with the python bindings.

Not sure if the ROOT dir in the Makefile actually needs to be changed, but the "build" directory for my zig installation creates a "zig-out" dir instead "build".