### PR TITLE
Compare Function for Rational/BigRational

### DIFF
--- a/src/lib/common/rational.zig
+++ b/src/lib/common/rational.zig
@@ -304,13 +304,6 @@ fn reduce_(r: anytype) void {
     assert(r.q >= 1);
 }
 
-fn cross_product(comptime T: type, r: anytype, s: anytype) !struct { ab: T, dc: T } {
-    return .{
-        .ab = try std.math.mul(T, r.p, s.p),
-        .dc = try std.math.mul(T, r.q, s.q),
-    };
-}
-
 fn multiplication(comptime T: type, r: anytype, p: anytype, q: anytype) !void {
     r.p = try std.math.mul(T, r.p, p);
     r.q = try std.math.mul(T, r.q, q);

--- a/src/lib/common/rational.zig
+++ b/src/lib/common/rational.zig
@@ -68,6 +68,11 @@ pub fn Rational(comptime T: type) type {
             return mul_(T, o, r, s);
         }
 
+        /// Compares two rationals using the identity (a/b) > (c/d) => ad > bc
+        pub fn cmp(r: *Self, s: anytype) Error!std.math.Order {
+            return cmp_(T, o, r, s);
+        }
+
         /// Normalize the rational by reducing by the greatest common divisor.
         pub fn reduce(r: *Self) void {
             reduce_(r);
@@ -113,6 +118,11 @@ pub fn Rational(comptime T: type) type {
         /// Multiplies two rationals.
         pub fn mul(r: *Self, s: anytype) Error!void {
             return mul_(T, o, r, s);
+        }
+
+        /// Compares two rationals using the identity (a/b) > (c/d) => ad > bc
+        pub fn cmp(r: *Self, s: anytype) Error!std.math.Order {
+            return cmp_(T, o, r, s);
         }
 
         /// Normalize the rational by reducing by the greatest common divisor.
@@ -247,6 +257,39 @@ fn mul_(comptime T: type, comptime o: comptime_int, r: anytype, s: anytype) !voi
     }
 }
 
+fn cmp_(comptime T: type, comptime o: comptime_int, r: anytype, s: anytype) !std.math.Order {
+    switch (@typeInfo(T)) {
+        Int => {
+            const ab = std.math.mul(T, r.p, s.q) catch |err| switch (err) {
+                error.Overflow => blk: {
+                    r.reduce();
+                    s.reduce();
+                    break :blk std.math.mul(T, r.p, s.q) catch unreachable;
+                },
+            };
+            const dc = std.math.mul(T, r.q, s.p) catch unreachable;
+
+            return std.math.order(ab, dc);
+        },
+        Float => {
+            if (r.q > o or r.p > o) r.reduce();
+            if (s.q > o or s.p > o) s.reduce();
+
+            const ab = std.math.mul(T, r.p, s.q) catch |err| switch (err) {
+                error.Overflow => blk: {
+                    r.reduce();
+                    s.reduce();
+                    break :blk std.math.mul(T, r.p, s.q) catch unreachable;
+                },
+            };
+            const dc = std.math.mul(T, r.q, s.p) catch unreachable;
+
+            return std.math.order(ab, dc);
+        },
+        else => unreachable,
+    }
+}
+
 fn reduce_(r: anytype) void {
     const d = gcd(r.p, r.q);
     if (d == 1) return;
@@ -259,6 +302,13 @@ fn reduce_(r: anytype) void {
 
     assert(r.p >= 1);
     assert(r.q >= 1);
+}
+
+fn cross_product(comptime T: type, r: anytype, s: anytype) !struct { ab: T, dc: T } {
+    return .{
+        .ab = try std.math.mul(T, r.p, s.p),
+        .dc = try std.math.mul(T, r.q, s.q),
+    };
 }
 
 fn multiplication(comptime T: type, r: anytype, p: anytype, q: anytype) !void {
@@ -388,6 +438,23 @@ test Rational {
         try r.add(&s);
         r.reduce();
         try expectEqual(Rational(t){ .p = 71, .q = 78 }, r);
+
+        var h = Rational(t){ .p = 3, .q = 5 };
+        // Same Denominator
+        var cmptr = Rational(t){ .p = 2, .q = 5 };
+        try expectEqual(h.cmp(&cmptr), .lt);
+        cmptr = Rational(t){ .p = 4, .q = 5 };
+        try expectEqual(h.cmp(&cmptr), .gt);
+
+        // Same Numerator
+        cmptr = Rational(t){ .p = 3, .q = 6 };
+        try expectEqual(h.cmp(&cmptr), .lt);
+        cmptr = Rational(t){ .p = 3, .q = 4 };
+        try expectEqual(h.cmp(&cmptr), .gt);
+
+        try doTurn(&h);
+        cmptr = Rational(t){ .p = 4567216874, .q = 89124781931234 };
+        try expectEqual(h.cmp(&cmptr), .lt);
     }
 }
 

--- a/src/lib/common/rational.zig
+++ b/src/lib/common/rational.zig
@@ -23,9 +23,10 @@ pub fn Rational(comptime T: type) type {
     // instead start reducing when we get sufficiently close to the limit of the mantissa
     // (in our domain we expect updates to involve numbers < 2**10, so we should be safe
     // not reducing before we are 2**10 away from "overflowing" the mantissa)
-    const o = if (@typeInfo(T) == Float) blk: {
-        break :blk std.math.pow(T, 2, std.math.floatMantissaBits(T) - 10);
-    } else 0;
+    const o = if (@typeInfo(T) == Float)
+        std.math.pow(T, 2, std.math.floatMantissaBits(T) - 10)
+    else
+        0;
 
     const Err = switch (@typeInfo(T)) {
         Int => error{Overflow},
@@ -263,11 +264,19 @@ fn cmp_(comptime T: type, comptime o: comptime_int, r: anytype, s: anytype) !std
             s.reduce();
 
             const ad = std.math.mul(T, r.p, s.q) catch |err| switch (err) {
-                error.Overflow => return error.Overflow,
+                error.Overflow => reduce: {
+                    r.reduce();
+                    s.reduce();
+                    break :reduce try std.math.mul(T, r.p, s.q);
+                },
                 else => unreachable,
             };
             const bc = std.math.mul(T, r.q, s.p) catch |err| switch (err) {
-                error.Overflow => return error.Overflow,
+                error.Overflow => reduce: {
+                    r.reduce();
+                    s.reduce();
+                    break :reduce try std.math.mul(T, r.q, s.p);
+                },
                 else => unreachable,
             };
 
@@ -395,7 +404,8 @@ fn doTurn(r: anytype) !void {
 
 test Rational {
     inline for (.{ u64, u128, u256, f64 }) |t| {
-        var r: Rational(t) = .{};
+        const R = Rational(t);
+        var r: R = .{};
 
         var c: t = 128;
         _ = &c;
@@ -417,15 +427,13 @@ test Rational {
 
         r.reset();
 
-        var s = Rational(t){ .p = 10, .q = 13 };
+        var s = R{ .p = 10, .q = 13 };
         try r.mul(&s);
-        s.reset();
-        try s.update(3, 4);
+        s = R{ .p = 3, .q = 4 };
         try r.mul(&s);
         try expectEqual(Rational(t){ .p = 30, .q = 52 }, r);
 
-        s.reset();
-        try s.update(1, 3);
+        s = R{ .p = 1, .q = 3 };
         try r.add(&s);
         r.reduce();
         try expectEqual(Rational(t){ .p = 71, .q = 78 }, r);
@@ -434,25 +442,20 @@ test Rational {
         // Same Denominator
         var cmptr = Rational(t){ .p = 2, .q = 5 };
         try expectEqual(h.cmp(&cmptr), .gt);
-        cmptr.reset();
-        try cmptr.update(4, 5);
+        cmptr = R{ .p = 4, .q = 5 };
         try expectEqual(h.cmp(&cmptr), .lt);
 
         // Same Numerator
-        cmptr.reset();
-        try cmptr.update(1, 2);
+        cmptr = R{ .p = 3, .q = 6 };
         try expectEqual(h.cmp(&cmptr), .gt);
-        cmptr.reset();
-        try cmptr.update(3, 4);
+        cmptr = R{ .p = 3, .q = 4 };
         try expectEqual(h.cmp(&cmptr), .lt);
 
-        cmptr.reset();
-        try cmptr.update(3, 5);
+        cmptr = R{ .p = 3, .q = 5 };
         try expectEqual(h.cmp(&cmptr), .eq);
 
         try doTurn(&h);
-        cmptr.reset();
-        try cmptr.update(4567216874, 89124781931235);
+        cmptr = R{ .p = 4567216874, .q = 89124781931235 };
         if (t == u64) {
             try expectEqual(h.cmp(&cmptr), error.Overflow);
         } else {

--- a/src/lib/common/rational.zig
+++ b/src/lib/common/rational.zig
@@ -23,10 +23,10 @@ pub fn Rational(comptime T: type) type {
     // instead start reducing when we get sufficiently close to the limit of the mantissa
     // (in our domain we expect updates to involve numbers < 2**10, so we should be safe
     // not reducing before we are 2**10 away from "overflowing" the mantissa)
-    const o = if (@typeInfo(T) == Float)
-        std.math.pow(T, 2, std.math.floatMantissaBits(T) - 10)
-    else
-        0;
+    const o = if (@typeInfo(T) == Float) blk: {
+        @setEvalBranchQuota(1500);
+        break :blk std.math.pow(T, 2, std.math.floatMantissaBits(T) - 10);
+    } else 0;
 
     const Err = switch (@typeInfo(T)) {
         Int => error{Overflow},
@@ -260,31 +260,28 @@ fn mul_(comptime T: type, comptime o: comptime_int, r: anytype, s: anytype) !voi
 fn cmp_(comptime T: type, comptime o: comptime_int, r: anytype, s: anytype) !std.math.Order {
     switch (@typeInfo(T)) {
         Int => {
-            const ab = std.math.mul(T, r.p, s.q) catch |err| switch (err) {
-                error.Overflow => blk: {
-                    r.reduce();
-                    s.reduce();
-                    break :blk std.math.mul(T, r.p, s.q) catch unreachable;
-                },
-            };
-            const dc = std.math.mul(T, r.q, s.p) catch unreachable;
+            r.reduce();
+            s.reduce();
 
-            return std.math.order(ab, dc);
+            const ad = std.math.mul(T, r.p, s.q) catch |err| switch (err) {
+                error.Overflow => return error.Overflow,
+                else => unreachable,
+            };
+            const bc = std.math.mul(T, r.q, s.p) catch |err| switch (err) {
+                error.Overflow => return error.Overflow,
+                else => unreachable,
+            };
+
+            return std.math.order(ad, bc);
         },
         Float => {
             if (r.q > o or r.p > o) r.reduce();
             if (s.q > o or s.p > o) s.reduce();
 
-            const ab = std.math.mul(T, r.p, s.q) catch |err| switch (err) {
-                error.Overflow => blk: {
-                    r.reduce();
-                    s.reduce();
-                    break :blk std.math.mul(T, r.p, s.q) catch unreachable;
-                },
-            };
-            const dc = std.math.mul(T, r.q, s.p) catch unreachable;
+            const ad: T = r.p * s.q;
+            const bc: T = r.q * s.p;
 
-            return std.math.order(ab, dc);
+            return std.math.order(ad, bc);
         },
         else => unreachable,
     }
@@ -435,19 +432,23 @@ test Rational {
         var h = Rational(t){ .p = 3, .q = 5 };
         // Same Denominator
         var cmptr = Rational(t){ .p = 2, .q = 5 };
-        try expectEqual(h.cmp(&cmptr), .lt);
-        cmptr = Rational(t){ .p = 4, .q = 5 };
         try expectEqual(h.cmp(&cmptr), .gt);
+        cmptr = Rational(t){ .p = 4, .q = 5 };
+        try expectEqual(h.cmp(&cmptr), .lt);
 
         // Same Numerator
         cmptr = Rational(t){ .p = 3, .q = 6 };
-        try expectEqual(h.cmp(&cmptr), .lt);
-        cmptr = Rational(t){ .p = 3, .q = 4 };
         try expectEqual(h.cmp(&cmptr), .gt);
+        cmptr = Rational(t){ .p = 3, .q = 4 };
+        try expectEqual(h.cmp(&cmptr), .lt);
 
         try doTurn(&h);
         cmptr = Rational(t){ .p = 4567216874, .q = 89124781931234 };
-        try expectEqual(h.cmp(&cmptr), .lt);
+        if (t == u64) {
+            try expectEqual(h.cmp(&cmptr), error.Overflow);
+        } else {
+            try expectEqual(h.cmp(&cmptr), .lt);
+        }
     }
 }
 

--- a/src/lib/common/rational.zig
+++ b/src/lib/common/rational.zig
@@ -24,7 +24,6 @@ pub fn Rational(comptime T: type) type {
     // (in our domain we expect updates to involve numbers < 2**10, so we should be safe
     // not reducing before we are 2**10 away from "overflowing" the mantissa)
     const o = if (@typeInfo(T) == Float) blk: {
-        @setEvalBranchQuota(1500);
         break :blk std.math.pow(T, 2, std.math.floatMantissaBits(T) - 10);
     } else 0;
 
@@ -420,11 +419,13 @@ test Rational {
 
         var s = Rational(t){ .p = 10, .q = 13 };
         try r.mul(&s);
-        s = Rational(t){ .p = 3, .q = 4 };
+        s.reset();
+        try s.update(3, 4);
         try r.mul(&s);
         try expectEqual(Rational(t){ .p = 30, .q = 52 }, r);
 
-        s = Rational(t){ .p = 1, .q = 3 };
+        s.reset();
+        try s.update(1, 3);
         try r.add(&s);
         r.reduce();
         try expectEqual(Rational(t){ .p = 71, .q = 78 }, r);
@@ -433,17 +434,25 @@ test Rational {
         // Same Denominator
         var cmptr = Rational(t){ .p = 2, .q = 5 };
         try expectEqual(h.cmp(&cmptr), .gt);
-        cmptr = Rational(t){ .p = 4, .q = 5 };
+        cmptr.reset();
+        try cmptr.update(4, 5);
         try expectEqual(h.cmp(&cmptr), .lt);
 
         // Same Numerator
-        cmptr = Rational(t){ .p = 3, .q = 6 };
+        cmptr.reset();
+        try cmptr.update(1, 2);
         try expectEqual(h.cmp(&cmptr), .gt);
-        cmptr = Rational(t){ .p = 3, .q = 4 };
+        cmptr.reset();
+        try cmptr.update(3, 4);
         try expectEqual(h.cmp(&cmptr), .lt);
 
+        cmptr.reset();
+        try cmptr.update(3, 5);
+        try expectEqual(h.cmp(&cmptr), .eq);
+
         try doTurn(&h);
-        cmptr = Rational(t){ .p = 4567216874, .q = 89124781931234 };
+        cmptr.reset();
+        try cmptr.update(4567216874, 89124781931235);
         if (t == u64) {
             try expectEqual(h.cmp(&cmptr), error.Overflow);
         } else {
@@ -504,6 +513,10 @@ pub const BigRational = struct {
     pub fn mul(r: *BigRational, s: *const BigRational) !void {
         try r.val.mul(r.val, s.val);
     }
+
+    pub fn cmp(r: *BigRational, s: *const BigRational) Error!std.math.Order {
+        return std.math.big.Rational.order(r.val, s.val);
+    }
 };
 
 test BigRational {
@@ -547,6 +560,9 @@ test BigRational {
 
     try s.setRatio(71, 78);
     try expect((try s.order(r.val)) == .eq);
+
+    try expectEqual(t.cmp(&r), .lt);
+    try expectEqual(r.cmp(&t), .gt);
 }
 
 test "minimum" {


### PR DESCRIPTION
Adds comparison methods to both `Rational` and `BigRational` structs for faster comparisons instead of converting to floats

Both return `std.math.Order` enums dictating the comparison order